### PR TITLE
'async' is a reserved word in Python >= 3.7

### DIFF
--- a/PyTorch/train.py
+++ b/PyTorch/train.py
@@ -55,7 +55,7 @@ def main():
 
             # Prepare sample and target
             image = torch.autograd.Variable(sample_batched['image'].cuda())
-            depth = torch.autograd.Variable(sample_batched['depth'].cuda(async=True))
+            depth = torch.autograd.Variable(sample_batched['depth'].cuda(non_blocking=True))
 
             # Normalize depth
             depth_n = DepthNorm( depth )
@@ -104,7 +104,7 @@ def LogProgress(model, writer, test_loader, epoch):
     sequential = test_loader
     sample_batched = next(iter(sequential))
     image = torch.autograd.Variable(sample_batched['image'].cuda())
-    depth = torch.autograd.Variable(sample_batched['depth'].cuda(async=True))
+    depth = torch.autograd.Variable(sample_batched['depth'].cuda(non_blocking=True))
     if epoch == 0: writer.add_image('Train.1.Image', vutils.make_grid(image.data, nrow=6, normalize=True), epoch)
     if epoch == 0: writer.add_image('Train.2.Depth', colorize(vutils.make_grid(depth.data, nrow=6, normalize=False)), epoch)
     output = DepthNorm( model(image) )


### PR DESCRIPTION
Fixes a __syntax error__ when running on Python >= 3.7 in alignment with pytorch/pytorch#4999

[flake8](http://flake8.pycqa.org) testing of https://github.com/ialhashim/DenseDepth on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics__
```
./PyTorch/train.py:58:78: E999 SyntaxError: invalid syntax
            depth = torch.autograd.Variable(sample_batched['depth'].cuda(async=True))
                                                                             ^
1     E999 SyntaxError: invalid syntax
1
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree