### PR TITLE
Add resizing to input image

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -27,7 +27,9 @@ def scale_up(scale, images):
 def load_images(image_files):
     loaded_images = []
     for file in image_files:
-        x = np.clip(np.asarray(Image.open( file ), dtype=float) / 255, 0, 1)
+        img = Image.open( file )
+        img = img.resize((640, 480), Image.ANTIALIAS)
+        x = np.clip(np.asarray(img, dtype=float) / 255, 0, 1)
         loaded_images.append(x)
     return np.stack(loaded_images, axis=0)
 


### PR DESCRIPTION
Resize input image during testing, otherwise error occurs if image of size other than (640, 480) is given.