### PR TITLE
AttributeError: module 'tensorflow' has no attribute 'get_default_graph' resolved

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -35,7 +35,7 @@ rgb_height = height_rgb
 
 import tensorflow as tf
 global graph,model
-graph = tf.get_default_graph()
+graph = tf.compat.v1.get_default_graph()
 
 def load_model():
     # Kerasa / TensorFlow


### PR DESCRIPTION
The following errors that occur when running the demo program on Tensorflow v2.x are resolved.
```bash
Traceback (most recent call last):
  File "demo.py", line 38, in <module>
    graph = tf.get_default_graph()
AttributeError: module 'tensorflow' has no attribute 'get_default_graph'
```