### PR TITLE
Fix bug in function evaluate

### DIFF
--- a/utils.py
+++ b/utils.py
@@ -111,14 +111,18 @@ def evaluate(model, rgb, depth, crop, batch_size=6, verbose=False):
 
     predictions = []
     testSetDepths = []
-    
-    for i in range(N//bs):    
-        x = rgb[(i)*bs:(i+1)*bs,:,:,:]
-        
+
+    for i in range(N//bs + 1):
+        sidx = i*bs
+        eidx = min((i+1)*bs, N)
+        if sidx == eidx:  # N is divisible by bs
+            break
+        x = rgb[sidx:eidx, :, :, :]
+
         # Compute results
         true_y = depth[(i)*bs:(i+1)*bs,:,:]
         pred_y = scale_up(2, predict(model, x/255, minDepth=10, maxDepth=1000, batch_size=bs)[:,:,:,0]) * 10.0
-        
+
         # Test time augmentation: mirror image estimate
         pred_y_flip = scale_up(2, predict(model, x[...,::-1,:]/255, minDepth=10, maxDepth=1000, batch_size=bs)[:,:,:,0]) * 10.0
 


### PR DESCRIPTION
In `evaluate`, the way how batches are calculated has a bug causing the
last batch of being left out from the evaluation. Consider e.g. `N = 11`,
thus `11 // 6 = 1` and `range(1) = 0`, so only first 6 images gets
evaluated.

To fix, loop to `N//bs + 1` and handle the last batch with size <= 6
carefully.