### PR TITLE
Fix demo.py not loading model

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -34,6 +34,7 @@ rgb_width = width_rgb
 rgb_height = height_rgb
 
 import tensorflow as tf
+tf.compat.v1.disable_eager_execution()
 global graph,model
 graph = tf.compat.v1.get_default_graph()
 


### PR DESCRIPTION
Fixes this error on loading the model:

```
Traceback (most recent call last):
  File "demo.py", line 149, in loadModel
    self.updateCloud()
  File "demo.py", line 202, in updateCloud
    depth = (1000 / self.model.predict( np.expand_dims(self.glWidget.rgb, axis=0)  )) / 1000
  File "C:\Users\Daniel\AppData\Local\Programs\Python\Python38\lib\site-packages\tensorflow\python\keras\engine\training.py", line 1577, in predict
    version_utils.disallow_legacy_graph('Model', 'predict')
  File "C:\Users\Daniel\AppData\Local\Programs\Python\Python38\lib\site-packages\tensorflow\python\keras\utils\version_utils.py", line 122, in disallow_legacy_graph
    raise ValueError(error_msg)
ValueError: Calling `Model.predict` in graph mode is not supported when the `Model` instance was constructed with eager mode enabled. Please construct your `Model` instance in graph mode or call `Model.predict` with eager mode enabled.
```